### PR TITLE
docs: update script sources from @v2.2.0 to @main

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ No backend required. No database. No API keys beyond a GitHub token scoped to is
 Add two lines to your page. The widget calls the GitHub API directly.
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js"></script>
 <script>
   IssueReporter.init({
     github: {
@@ -78,7 +78,7 @@ This token can *only* create issues on that one repo. It can't read your code, p
 Token stays on your server. The widget POSTs JSON to a route on your app, your app runs `gh issue create`. No token in the browser, no extra process.
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js"></script>
 <script>
   IssueReporter.init({ endpoint: "/api/report", projectName: "My App" });
 </script>
@@ -300,7 +300,7 @@ For a more complete backend with rate limiting, CORS, labels, and conventional-c
 The widget works with any GitHub-compatible instance. Pass `apiUrl` in the `github` config to target on-prem or alternative deployments:
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js"></script>
 <script>
   IssueReporter.init({
     github: {
@@ -333,7 +333,7 @@ The widget works with any GitHub-compatible instance. Pass `apiUrl` in the `gith
 ## Widget Options
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js"></script>
 <script>
   IssueReporter.init({
     // --- Pick one mode ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -624,7 +624,7 @@ tr:last-child td { border-bottom: none; }
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.08 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.5 1 .11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 016.02 0c2.28-1.55 3.28-1.23 3.28-1.23.66 1.66.26 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.42.36.81 1.1.81 2.22v3.29c0 .32.22.7.82.58A12.01 12.01 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         GitHub
       </a>
-      <a href="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js" class="btn btn-secondary" target="_blank" rel="noopener">
+      <a href="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js" class="btn btn-secondary" target="_blank" rel="noopener">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         CDN
       </a>
@@ -710,7 +710,7 @@ tr:last-child td { border-bottom: none; }
             Copy
           </button>
         </div>
-        <pre><code class="language-html">&lt;script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js"&gt;&lt;/script&gt;
+        <pre><code class="language-html">&lt;script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js"&gt;&lt;/script&gt;
 &lt;script&gt;
   IssueReporter.init({
     github: {
@@ -753,7 +753,7 @@ tr:last-child td { border-bottom: none; }
             Copy
           </button>
         </div>
-        <pre><code class="language-html">&lt;script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js"&gt;&lt;/script&gt;
+        <pre><code class="language-html">&lt;script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js"&gt;&lt;/script&gt;
 &lt;script&gt;
   IssueReporter.init({ endpoint: "/api/report", projectName: "My App" });
 &lt;/script&gt;</code></pre>
@@ -1032,7 +1032,7 @@ def report_issue(request):
             Copy
           </button>
         </div>
-        <pre><code class="language-html">&lt;script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js"&gt;&lt;/script&gt;
+        <pre><code class="language-html">&lt;script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js"&gt;&lt;/script&gt;
 &lt;script&gt;
   IssueReporter.init({
     github: {
@@ -1096,7 +1096,7 @@ def report_issue(request):
             Copy
           </button>
         </div>
-        <pre><code class="language-html">&lt;script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js"&gt;&lt;/script&gt;
+        <pre><code class="language-html">&lt;script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js"&gt;&lt;/script&gt;
 &lt;script&gt;
   IssueReporter.init({
     // --- Pick one mode ---
@@ -1268,7 +1268,7 @@ print(url)  # https://github.com/you/repo/issues/42</code></pre>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
 
 <!-- Issue Reporter widget (live demo) -->
-<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@v2.2.0/issue-reporter.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/rayketcham-lab/issue-reporter@main/issue-reporter.js"></script>
 <script>
   // Initialize with a dummy endpoint so it doesn't actually submit
   IssueReporter.init({


### PR DESCRIPTION
## Summary
- Updates all 10 CDN script source references from `@v2.2.0` to `@main` in README.md (4) and docs/index.html (6)
- Supersedes branches `rayketcham-patch-1` and `rayketcham-patch-2` which only caught 1 of the 10 occurrences

## Test plan
- [ ] Verify CDN links resolve correctly with `@main`
- [ ] Check GitHub Pages site renders updated code examples

Generated with Claude Code