### PR TITLE
ci: add JS-only validation workflow (syntax + SRI reciprocity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate widget + docs integrity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history + tags for SRI verification)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: JS syntax check (zero-dependency widget)
+        run: node --check issue-reporter.js
+
+      - name: SRI hashes match the pinned release artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          status=0
+          for f in README.md docs/index.html; do
+            if [[ ! -f "$f" ]]; then echo "::error::$f missing"; status=1; continue; fi
+
+            mapfile -t tags < <(grep -oE 'issue-reporter@[A-Za-z0-9._-]+/issue-reporter\.js' "$f" \
+                                  | sed -E 's#.*@([A-Za-z0-9._-]+)/issue-reporter\.js#\1#' | sort -u)
+            mapfile -t hashes < <(grep -oE 'integrity="sha384-[A-Za-z0-9+/=]+"' "$f" \
+                                  | sed -E 's#integrity="(sha384-[A-Za-z0-9+/=]+)"#\1#' | sort -u)
+
+            if [[ "${#tags[@]}" -ne 1 ]]; then
+              echo "::error file=$f::expected exactly one pinned @tag, found: ${tags[*]:-(none)}"
+              status=1; continue
+            fi
+            if [[ "${#hashes[@]}" -ne 1 ]]; then
+              echo "::error file=$f::expected exactly one integrity hash, found: ${hashes[*]:-(none)}"
+              status=1; continue
+            fi
+
+            tag="${tags[0]}"
+            # The CDN reference MUST be an immutable git tag. A mutable branch (e.g. @main)
+            # would let the documented hash silently drift while CI stays green, defeating SRI.
+            if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+              echo "::error file=$f::reference @${tag} is not an immutable git tag (mutable refs are not allowed)"
+              status=1; continue
+            fi
+            if ! git cat-file -e "refs/tags/${tag}:issue-reporter.js" 2>/dev/null; then
+              echo "::error file=$f::tag ${tag} has no issue-reporter.js"
+              status=1; continue
+            fi
+            expect="sha384-$(git show "refs/tags/${tag}:issue-reporter.js" | openssl dgst -sha384 -binary | openssl base64 -A)"
+
+            if [[ "${hashes[0]}" != "$expect" ]]; then
+              echo "::error file=$f::SRI mismatch for @${tag} — documented ${hashes[0]}, artifact is $expect"
+              status=1
+            else
+              echo "OK  $f  @${tag}  ${hashes[0]}"
+            fi
+          done
+          exit "$status"


### PR DESCRIPTION
## What

`main` had no `ci.yml` — CodeQL was the only workflow. This adds a real, JS-only CI matching the v2.3.0 reality (single-file, zero-dependency widget; no Python/shell/tests).

**Job `validate` (ubuntu-latest):**
- `node --check issue-reporter.js` — widget parses.
- **SRI reciprocity:** every `integrity=` hash in `README.md`/`docs/index.html` must equal `sha384` of `issue-reporter.js` **at the immutable git tag** pinned in the same CDN URL. Mutable refs (e.g. `@main`), missing/duplicate hashes, or a wrong hash all fail the build.

## Why this is legit + reciprocal
- All actions **SHA-pinned** (`checkout@de0fac2e`, v6.0.2) per org `sha_pinning_required`; least-privilege `contents: read`; no `continue-on-error`/`|| true`.
- Green ⟺ the documented integrity hash genuinely matches the published artifact at an immutable tag.

## Verified before opening
- `node --check` and SRI check pass against current `main`.
- Mutation tests: flipped hash rejected; `@main` mutable ref rejected.
- 4-agent adversarial audit (DevOps/SecOps/Reciprocity/Reality); the one real finding (mutable-ref loophole) is fixed here.

Follow-up after green: set `Validate widget + docs integrity` as a required status check on `main`.

Generated with Claude Code