### PR TITLE
ci: bump codeql-action init + analyze together to v4.36.3 (fixes #30, #31)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
-      - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3


### PR DESCRIPTION
## Problem

Dependabot opened **#30** (`codeql-action/analyze`) and **#31** (`codeql-action/init`) as two separate PRs, each bumping only one of the two `github/codeql-action` steps in `codeql.yml`. CodeQL requires **all** `codeql-action/*` steps in a workflow to run the **same** version, so each PR on its own produces a 4.36.3 / 4.35.2 split and the `Analyze` job fails:

```
##[warning] Not all workflow steps that use `github/codeql-action` use the same version.
##[error] Loaded a configuration file for version '4.36.3', but running version '4.35.2'
```

That's why #30 and #31 are both red.

## Fix

Bump **both** `init` and `analyze` to `v4.36.3` (`54f647b`, the same commit SHA dependabot resolved) in a single commit, keeping them in lockstep and SHA-pinned per the org policy.

Once merged, dependabot will auto-close #30 and #31.

## Verification

- Diff is exactly the two `uses:` SHA lines; workflow structure unchanged.
- Both SHAs match dependabot's own resolution of `v4.36.3`.

Generated with Claude Code