### PR TITLE
security: strip query strings from captured API URLs before reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  a11y:
+    name: A11y focus tests (jsdom)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # Uses the Node.js preinstalled on the runner (no extra pinned action).
+      - name: Show Node version
+        run: node --version
+
+      - name: Install dev dependencies (jsdom)
+        run: npm install --no-audit --no-fund
+
+      - name: Run accessibility test suite
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ issue-reporter.conf
 # OS
 .DS_Store
 Thumbs.db
+
+# Node (dev/test tooling only — the widget itself ships zero dependencies)
+node_modules/
+package-lock.json

--- a/issue-reporter.js
+++ b/issue-reporter.js
@@ -120,6 +120,7 @@
   var backdropEl = null;
   var buttonEl = null;
   var inspectBannerEl = null;
+  var previouslyFocused = null; // element focused before the modal opened, restored on close
 
   // Wizard state
   var state = {
@@ -1375,6 +1376,7 @@
         onClick: function () {
           state.step--;
           renderContent();
+          setTimeout(focusModalStart, 50);
         },
       }, ["\u2190 Back"]);
       footer.appendChild(backBtn);
@@ -1392,13 +1394,7 @@
           if (state.step === 0 && !state.selectedType) return;
           state.step++;
           renderContent();
-          // Focus description on step 1
-          if (state.step === 1) {
-            setTimeout(function () {
-              var desc = document.getElementById("ir-desc");
-              if (desc) desc.focus();
-            }, 50);
-          }
+          setTimeout(focusModalStart, 50);
         },
       }, ["Next \u2192"]);
       if (nextDisabled) {
@@ -1526,7 +1522,9 @@
       children.push(el("button", {
         className: "ir-status-action",
         type: "button",
-        onClick: closeModal,
+        onClick: function () {
+          closeModal();
+        },
       }, "Done"));
       return el("div", { className: "ir-status" }, children);
     }
@@ -1592,7 +1590,11 @@
 
     var closeBtn = el("button", {
       className: "ir-close",
-      onClick: closeModal,
+      // Wrap so the click Event isn't passed as closeModal's `silent` arg,
+      // which would suppress state reset and focus restoration.
+      onClick: function () {
+        closeModal();
+      },
       "aria-label": "Close",
       type: "button",
     }, "\u2715");
@@ -1606,6 +1608,7 @@
       role: "dialog",
       "aria-modal": "true",
       "aria-label": titleText,
+      tabindex: "-1",
     }, [header, content]);
 
     // Prevent clicks inside modal from closing
@@ -1638,8 +1641,90 @@
     state.result = null;
   }
 
+  // -------------------------------------------------------------------------
+  // Focus management (WAI-ARIA dialog pattern)
+  // -------------------------------------------------------------------------
+
+  var FOCUSABLE_SELECTOR =
+    "a[href], button, textarea, input:not([type=hidden]), select, [tabindex]";
+
+  /** Focusable, tabbable descendants of a container, in DOM order. */
+  function getFocusable(container) {
+    if (!container) return [];
+    var nodes = container.querySelectorAll(FOCUSABLE_SELECTOR);
+    var out = [];
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      if (node.disabled) continue;
+      if (node.getAttribute("tabindex") === "-1") continue;
+      out.push(node);
+    }
+    return out;
+  }
+
+  /** Whether the modal is currently open and visible. */
+  function isModalOpen() {
+    return !!(backdropEl && backdropEl.classList.contains("ir-backdrop--visible"));
+  }
+
+  /**
+   * Move focus to the first sensible control for the current step.
+   * Prefers the description field (step 1), then the first focusable control
+   * in the content area, then the modal container itself as a last resort.
+   */
+  function focusModalStart() {
+    if (!modalEl) return;
+    var content = document.getElementById("ir-content");
+    var desc = document.getElementById("ir-desc");
+    var target = desc || getFocusable(content)[0] || modalEl;
+    if (target && typeof target.focus === "function") {
+      target.focus();
+    }
+  }
+
+  /**
+   * Make everything outside the dialog inert + hidden from assistive tech
+   * while the modal is open (on=true), and restore prior state on close.
+   * The previous aria-hidden value is stashed in a data attribute so we
+   * don't clobber a page that manages its own aria-hidden.
+   */
+  function setBackgroundInert(on) {
+    if (!document.body) return;
+    // Snapshot of top-level nodes at open time. Nodes the host page appends
+    // while the modal is open are not inerted, but the Tab trap in
+    // handleKeydown still keeps keyboard focus inside the dialog.
+    var children = document.body.children;
+    for (var i = 0; i < children.length; i++) {
+      var node = children[i];
+      if (node === backdropEl) continue;
+      if (on) {
+        if (node.hasAttribute("data-ir-inert")) continue;
+        node.setAttribute("data-ir-inert", node.getAttribute("aria-hidden") || "");
+        node.setAttribute("aria-hidden", "true");
+        node.setAttribute("inert", "");
+      } else {
+        if (!node.hasAttribute("data-ir-inert")) continue;
+        var prev = node.getAttribute("data-ir-inert");
+        node.removeAttribute("inert");
+        if (prev) {
+          node.setAttribute("aria-hidden", prev);
+        } else {
+          node.removeAttribute("aria-hidden");
+        }
+        node.removeAttribute("data-ir-inert");
+      }
+    }
+  }
+
   function openModal() {
     if (inspectActive) return;
+
+    // Remember what had focus so we can restore it on close. Capture only when
+    // not already tracking a target, so re-opening from inspect mode (a silent
+    // close that preserves previouslyFocused) keeps the original trigger element.
+    if (!previouslyFocused) {
+      previouslyFocused = document.activeElement;
+    }
 
     if (!modalEl) {
       createModal();
@@ -1670,13 +1755,12 @@
       buttonEl.style.display = "none";
     }
 
-    // Focus description on step 1
-    if (state.step === 1) {
-      setTimeout(function () {
-        var desc = document.getElementById("ir-desc");
-        if (desc) desc.focus();
-      }, 250);
-    }
+    // Take the rest of the page out of the tab order / accessibility tree.
+    setBackgroundInert(true);
+
+    // Move focus into the dialog for the current step (every step, not just
+    // step 1). Deferred so the freshly-rendered, now-visible content is focusable.
+    setTimeout(focusModalStart, 0);
   }
 
   function closeModal(silent) {
@@ -1687,18 +1771,37 @@
     if (!backdropEl) return;
     backdropEl.classList.remove("ir-backdrop--visible");
 
+    // Restore the rest of the page immediately so it is interactive again
+    // (including during inspect mode, where the modal hides but the page stays live).
+    setBackgroundInert(false);
+
+    var restoreTarget = silent ? null : previouslyFocused;
+
     setTimeout(function () {
+      // If the modal was re-opened during the close animation, abandon teardown
+      // so we don't hide the now-visible dialog or steal focus back.
+      if (isModalOpen()) return;
       if (backdropEl) {
         backdropEl.style.display = "none";
       }
       if (buttonEl && !silent) {
         buttonEl.style.display = "";
       }
+      // Return focus to whatever had it before opening (usually the trigger button),
+      // now that the button is visible again. Guard against a stale/detached node.
+      if (
+        restoreTarget &&
+        typeof restoreTarget.focus === "function" &&
+        document.contains(restoreTarget)
+      ) {
+        restoreTarget.focus();
+      }
     }, 250);
 
     // Reset state on close (unless silent close for inspect mode)
     if (!silent) {
       resetState();
+      previouslyFocused = null;
     }
   }
 
@@ -1710,8 +1813,31 @@
     if (e.key === "Escape") {
       if (inspectActive) {
         cancelInspect();
-      } else if (backdropEl && backdropEl.classList.contains("ir-backdrop--visible")) {
+      } else if (isModalOpen()) {
         closeModal();
+      }
+      return;
+    }
+
+    // Trap Tab within the open dialog so focus can never reach the inert page behind it.
+    if (e.key === "Tab" && !inspectActive && isModalOpen() && modalEl) {
+      var focusable = getFocusable(modalEl);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        modalEl.focus();
+        return;
+      }
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      var active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || !modalEl.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !modalEl.contains(active)) {
+        e.preventDefault();
+        first.focus();
       }
     }
   }
@@ -1814,6 +1940,9 @@
       // End inspect mode if active
       endInspect();
 
+      // Undo any background inert-ing before we drop our references to it
+      setBackgroundInert(false);
+
       // Remove DOM elements
       if (buttonEl && buttonEl.parentNode) {
         buttonEl.parentNode.removeChild(buttonEl);
@@ -1838,6 +1967,7 @@
       modalEl = null;
       backdropEl = null;
       inspectBannerEl = null;
+      previouslyFocused = null;
       config = {};
       resetState();
       this._initialized = false;

--- a/issue-reporter.js
+++ b/issue-reporter.js
@@ -562,10 +562,14 @@
         // Only capture /api/ calls, skip our own issue endpoints
         if (url.indexOf("/api/") === 0 && url.indexOf("/issues/") === -1) {
           try {
+            // Strip the query string / fragment before storing. The captured
+            // URL is transmitted into the issue report, and query strings on
+            // host-app API calls may carry secrets (e.g. ?token=, ?sig=).
+            var safeUrl = url.split("?")[0].split("#")[0];
             var clone = response.clone();
             clone.text().then(function (body) {
               apiCalls.push({
-                url: url,
+                url: safeUrl,
                 status: response.status,
                 body: body.slice(0, 500),
                 ts: Date.now(),

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "issue-reporter",
+  "version": "2.3.0",
+  "private": true,
+  "description": "Zero-dependency, single-file in-page issue reporter widget.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/a11y_focus.test.mjs"
+  },
+  "devDependencies": {
+    "jsdom": "^24.1.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "test": "node tests/a11y_focus.test.mjs"
+    "test": "node tests/a11y_focus.test.mjs && node tests/fetch_capture_redaction.test.mjs"
   },
   "devDependencies": {
     "jsdom": "^24.1.3"

--- a/tests/a11y_focus.test.mjs
+++ b/tests/a11y_focus.test.mjs
@@ -1,0 +1,286 @@
+// Accessibility focus-management tests for the report modal (issue #26).
+//
+// Drives the *real* issue-reporter.js inside jsdom and asserts the WAI-ARIA
+// dialog focus contract: focus enters the dialog on open, Tab/Shift+Tab are
+// trapped, the background is made inert, and focus is restored on close.
+//
+// Run: node tests/a11y_focus.test.mjs   (from the package dir; needs jsdom)
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { JSDOM } from "jsdom";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const widgetSrc = readFileSync(join(here, "..", "issue-reporter.js"), "utf8");
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let passed = 0;
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) {
+    passed++;
+    console.log("  ✓ " + msg);
+  } else {
+    failed++;
+    console.error("  ✗ " + msg);
+  }
+}
+
+// Fresh document + initialized widget for each test.
+function setup(fetchStub) {
+  const dom = new JSDOM(
+    `<!DOCTYPE html><html><body>
+       <header id="page-header"><a href="#main" id="skip">Skip</a></header>
+       <main id="main"><button id="page-btn">Page button</button></main>
+     </body></html>`,
+    { url: "https://example.test/", runScripts: "outside-only", pretendToBeVisual: true }
+  );
+  const { window } = dom;
+  // Expose globals the widget expects, then evaluate it in this window.
+  const g = ["window", "document", "navigator", "location", "setTimeout", "clearTimeout", "console", "fetch"];
+  const fn = new window.Function(...g, widgetSrc + "\n;return window.IssueReporter;");
+  const fetchImpl = fetchStub || (() => Promise.reject(new Error("no network in test")));
+  const IssueReporter = fn(
+    window, window.document, window.navigator, window.location,
+    window.setTimeout, window.clearTimeout, window.console, fetchImpl
+  );
+  IssueReporter.init({ github: { repo: "acme/app", token: "github_pat_x" }, projectName: "T" });
+  // jsdom stays in readyState "loading", so the widget defers createButton to
+  // DOMContentLoaded — fire it so the trigger button exists (as in a real page).
+  window.document.dispatchEvent(new window.Event("DOMContentLoaded", { bubbles: true }));
+  return { window, document: window.document, IssueReporter };
+}
+
+function tab(window, { shift = false } = {}) {
+  const doc = window.document;
+  const ev = new window.KeyboardEvent("keydown", {
+    key: "Tab", shiftKey: shift, bubbles: true, cancelable: true,
+  });
+  doc.dispatchEvent(ev);
+  return ev;
+}
+
+async function testFocusEntersOnStep0() {
+  console.log("focus enters the dialog on open (step 0)");
+  const { window, document, IssueReporter } = setup();
+  const trigger = document.querySelector(".ir-btn");
+  trigger.focus();
+  assert(document.activeElement === trigger, "trigger button is focused before open");
+
+  IssueReporter.open();
+  await sleep(10); // let the deferred focusModalStart run
+
+  const modal = document.querySelector(".ir-modal");
+  assert(modal.contains(document.activeElement), "focus moved inside the dialog on step 0");
+  assert(
+    document.activeElement.classList.contains("ir-type-card"),
+    "first type card receives focus on step 0 (not the hidden trigger)"
+  );
+}
+
+async function testTabTrap() {
+  console.log("Tab / Shift+Tab are trapped within the dialog");
+  const { window, document, IssueReporter } = setup();
+  IssueReporter.open();
+  await sleep(10);
+  const modal = document.querySelector(".ir-modal");
+
+  // Walk Tab forward many times — focus must never leave the modal.
+  let leaked = false;
+  for (let i = 0; i < 40; i++) {
+    tab(window);
+    if (!modal.contains(document.activeElement)) { leaked = true; break; }
+  }
+  assert(!leaked, "Tab never lands on page content behind the backdrop");
+
+  // Shift+Tab from the first control wraps to the last.
+  const focusable = modal.querySelectorAll(
+    "a[href], button:not([disabled]), textarea, input, select"
+  );
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  first.focus();
+  const ev = tab(window, { shift: true });
+  assert(ev.defaultPrevented, "Shift+Tab at the first control is intercepted");
+  assert(document.activeElement === last, "Shift+Tab from first wraps to last");
+
+  // Tab from the last control wraps to the first.
+  last.focus();
+  const ev2 = tab(window);
+  assert(ev2.defaultPrevented, "Tab at the last control is intercepted");
+  assert(document.activeElement === first, "Tab from last wraps to first");
+}
+
+async function testBackgroundInert() {
+  console.log("background is inert + hidden from assistive tech while open");
+  const { window, document, IssueReporter } = setup();
+  const header = document.getElementById("page-header");
+  const main = document.getElementById("main");
+
+  IssueReporter.open();
+  await sleep(10);
+
+  assert(header.hasAttribute("inert") && header.getAttribute("aria-hidden") === "true",
+    "page header is inert + aria-hidden while modal open");
+  assert(main.hasAttribute("inert") && main.getAttribute("aria-hidden") === "true",
+    "page main is inert + aria-hidden while modal open");
+  const backdrop = document.querySelector(".ir-backdrop");
+  assert(!backdrop.hasAttribute("inert"), "the dialog's own backdrop is NOT inert");
+
+  IssueReporter.close();
+  await sleep(300);
+  assert(!header.hasAttribute("inert") && !header.hasAttribute("aria-hidden"),
+    "page header inert + aria-hidden removed after close");
+  assert(!main.hasAttribute("inert") && !main.hasAttribute("aria-hidden"),
+    "page main inert + aria-hidden removed after close");
+}
+
+async function testFocusRestoredOnClose(label, closeFn) {
+  console.log("focus restored to trigger on close via " + label);
+  const { window, document, IssueReporter } = setup();
+  const trigger = document.querySelector(".ir-btn");
+  trigger.focus();
+  IssueReporter.open();
+  await sleep(10);
+  const modal = document.querySelector(".ir-modal");
+  assert(modal.contains(document.activeElement), "focus is inside modal before close");
+
+  closeFn({ window, document, IssueReporter });
+  await sleep(300); // close animation timeout + focus restore
+
+  assert(document.activeElement === trigger,
+    "focus returned to the trigger button after " + label);
+}
+
+function pressEscape({ window, document }) {
+  document.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+}
+function clickBackdrop({ window, document }) {
+  document.querySelector(".ir-backdrop").dispatchEvent(new window.Event("click", { bubbles: true }));
+}
+function clickCloseX({ window, document }) {
+  document.querySelector(".ir-close").dispatchEvent(new window.Event("click", { bubbles: true }));
+}
+
+async function testDoneRestoresFocus() {
+  console.log("focus restored to trigger on close via the Done button (after submit)");
+  const okFetch = () =>
+    Promise.resolve({ ok: true, status: 201, json: () => Promise.resolve({ html_url: "https://github.com/acme/app/issues/1" }) });
+  const { window, document, IssueReporter } = setup(okFetch);
+  const trigger = document.querySelector(".ir-btn");
+  trigger.focus();
+
+  IssueReporter.open();
+  await sleep(10);
+  // Step 0: pick the first type.
+  document.querySelector(".ir-type-card").dispatchEvent(new window.Event("click", { bubbles: true }));
+  document.querySelector(".ir-footer-next").dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(60);
+  // Step 1: fill the description.
+  const desc = document.getElementById("ir-desc");
+  desc.value = "Something is broken on this page";
+  desc.dispatchEvent(new window.Event("input", { bubbles: true }));
+  document.querySelector(".ir-footer-next").dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(60);
+  // Step 2: submit.
+  document.querySelector(".ir-footer-submit").dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(60);
+
+  const done = document.querySelector(".ir-status-action");
+  assert(!!done, "result screen with a Done button is shown after successful submit");
+  done.dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(300);
+  assert(document.activeElement === trigger, "focus returned to the trigger button after Done");
+}
+
+async function testReopenDuringCloseAnimation() {
+  console.log("re-opening within the close animation window is not torn down");
+  const { window, document, IssueReporter } = setup();
+  document.querySelector(".ir-btn").focus();
+  IssueReporter.open();
+  await sleep(10);
+  IssueReporter.close();        // schedules a 250ms teardown
+  await sleep(20);              // still within the window
+  IssueReporter.open();         // re-open before teardown fires
+  await sleep(10);
+  const modal = document.querySelector(".ir-modal");
+  assert(modal.contains(document.activeElement), "focus is inside the re-opened modal");
+
+  await sleep(300);            // let the stale teardown timer fire
+  const backdrop = document.querySelector(".ir-backdrop");
+  assert(backdrop.classList.contains("ir-backdrop--visible"),
+    "re-opened modal stays visible after the stale timer fires");
+  assert(backdrop.style.display !== "none", "backdrop was not hidden by the stale timer");
+  assert(modal.contains(document.activeElement),
+    "focus was not stolen back to the trigger by the stale timer");
+}
+
+async function testInspectPreservesRestoreTarget() {
+  console.log("inspect mode round-trip preserves the focus-restore target");
+  const { window, document, IssueReporter } = setup();
+  const trigger = document.querySelector(".ir-btn");
+  trigger.focus();
+  IssueReporter.open();
+  await sleep(10);
+  // Advance to step 1 where the inspect button lives.
+  document.querySelector(".ir-type-card").dispatchEvent(new window.Event("click", { bubbles: true }));
+  document.querySelector(".ir-footer-next").dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(60);
+
+  const inspectBtn = document.querySelector(".ir-inspect-btn");
+  assert(!!inspectBtn, "inspect button is present on step 1");
+  inspectBtn.dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(300); // silent close animation
+
+  // Background must be interactive again during inspect (not inert).
+  assert(!document.getElementById("main").hasAttribute("inert"),
+    "background is NOT inert while inspecting the page");
+
+  // Simulate picking a page element (fires the capture-phase click handler → reopens modal).
+  document.getElementById("page-btn").dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(60);
+  assert(document.querySelector(".ir-modal") && isVisible(document), "modal re-opened after capture");
+
+  // Now close for real — focus must go back to the ORIGINAL trigger, not <body>.
+  IssueReporter.close();
+  await sleep(300);
+  assert(document.activeElement === trigger,
+    "focus restored to the original trigger after an inspect round-trip");
+}
+
+function isVisible(document) {
+  const b = document.querySelector(".ir-backdrop");
+  return b && b.classList.contains("ir-backdrop--visible");
+}
+
+async function testAriaModalWiring() {
+  console.log("dialog semantics are present");
+  const { document, IssueReporter } = setup();
+  IssueReporter.open();
+  await sleep(10);
+  const modal = document.querySelector(".ir-modal");
+  assert(modal.getAttribute("role") === "dialog", 'role="dialog" present');
+  assert(modal.getAttribute("aria-modal") === "true", 'aria-modal="true" present');
+  assert(modal.getAttribute("tabindex") === "-1", "modal has tabindex=-1 fallback");
+}
+
+const run = async () => {
+  console.log("\nA11y focus-management tests (issue #26)\n");
+  await testAriaModalWiring();
+  await testFocusEntersOnStep0();
+  await testTabTrap();
+  await testBackgroundInert();
+  await testFocusRestoredOnClose("Escape", pressEscape);
+  await testFocusRestoredOnClose("backdrop click", clickBackdrop);
+  await testFocusRestoredOnClose("the ✕ button", clickCloseX);
+  await testDoneRestoresFocus();
+  await testInspectPreservesRestoreTarget();
+  await testReopenDuringCloseAnimation();
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed === 0 ? 0 : 1);
+};
+
+run();

--- a/tests/fetch_capture_redaction.test.mjs
+++ b/tests/fetch_capture_redaction.test.mjs
@@ -1,0 +1,84 @@
+// Security regression test: the fetch-capture wrapper must not leak query
+// strings (which can carry secrets like ?token=) into the submitted issue.
+//
+// Run: node tests/fetch_capture_redaction.test.mjs   (needs jsdom)
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { JSDOM } from "jsdom";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const widgetSrc = readFileSync(join(here, "..", "issue-reporter.js"), "utf8");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { passed++; console.log("  ✓ " + msg); }
+  else { failed++; console.error("  ✗ " + msg); }
+}
+
+async function run() {
+  console.log("\nfetch-capture query-string redaction (security)\n");
+
+  const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>", {
+    url: "https://app.test/", runScripts: "outside-only", pretendToBeVisual: true,
+  });
+  const { window } = dom;
+
+  // A host-app fetch that the widget's capture wrapper will wrap. Returns a
+  // minimal Response-like object with clone().text().
+  window.fetch = function () {
+    return Promise.resolve({
+      status: 200,
+      clone: function () { return { text: function () { return Promise.resolve("{}"); } }; },
+    });
+  };
+
+  // Separate recording mock for the widget's OWN submit (bare `fetch` global),
+  // capturing the JSON body sent to the GitHub API.
+  let sentBody = null;
+  const submitFetch = (url, opts) => {
+    sentBody = opts && opts.body;
+    return Promise.resolve({ ok: true, status: 201, json: () => Promise.resolve({ html_url: "https://github.com/a/b/issues/1" }) });
+  };
+
+  const g = ["window", "document", "navigator", "location", "setTimeout", "clearTimeout", "console", "fetch"];
+  const fn = new window.Function(...g, widgetSrc + "\n;return window.IssueReporter;");
+  const IssueReporter = fn(
+    window, window.document, window.navigator, window.location,
+    window.setTimeout, window.clearTimeout, window.console, submitFetch
+  );
+  IssueReporter.init({ github: { repo: "a/b", token: "github_pat_x" }, projectName: "T" });
+  window.document.dispatchEvent(new window.Event("DOMContentLoaded", { bubbles: true }));
+
+  // Host app makes an API call with a secret in the query string.
+  await window.fetch("/api/session?token=SECRET_TOKEN_123&user=bob");
+  await sleep(20); // let the capture's clone().text().then() settle
+
+  // Drive a full submit through the wizard.
+  const doc = window.document;
+  IssueReporter.open();
+  await sleep(10);
+  doc.querySelector(".ir-type-card").dispatchEvent(new window.Event("click", { bubbles: true }));
+  doc.querySelector(".ir-footer-next").dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(60);
+  const desc = doc.getElementById("ir-desc");
+  desc.value = "A description of the problem here";
+  desc.dispatchEvent(new window.Event("input", { bubbles: true }));
+  doc.querySelector(".ir-footer-next").dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(60);
+  doc.querySelector(".ir-footer-submit").dispatchEvent(new window.Event("click", { bubbles: true }));
+  await sleep(60);
+
+  assert(sentBody != null, "the widget submitted an issue payload");
+  const body = String(sentBody);
+  assert(body.indexOf("/api/session") !== -1, "the captured API path is still reported (feature preserved)");
+  assert(body.indexOf("SECRET_TOKEN_123") === -1, "the query-string secret is NOT in the issue payload");
+  assert(body.indexOf("token=") === -1, "no raw query string leaked into the issue payload");
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+run();


### PR DESCRIPTION
## Summary

An adversarial security review of the widget (verdict: LOW risk, approved) surfaced one real, fixable exfiltration path. This closes it.

**Data flow:** `installFetchCapture` records recent same-origin `/api/` calls → `apiCalls[].url` → `formatIssueBody` renders them under "Recent API Calls" → sent to the GitHub API as the issue body.

**Risk:** the captured URL includes the **query string**. Host apps commonly put secrets there (`/api/session?token=…`, `?sig=…`, session ids). Those would be copied verbatim into a potentially public GitHub issue.

**Fix:** strip the query string and fragment before storing the URL (`url.split("?")[0].split("#")[0]`). The path is still reported, so the debugging signal is preserved; only the secret-bearing tail is dropped.

## Test

`tests/fetch_capture_redaction.test.mjs` drives a full submit after a host-app call to `/api/session?token=SECRET_TOKEN_123` and asserts the secret never appears in the issue payload while the path still does. Verified it **fails against the pre-fix code** and passes after.

## Notes

- **Stacked on #32** (`fix/a11y-modal-focus-26`) so it reuses that PR's `package.json` / `Test` workflow — the diff resolves to just this security commit once #32 merges. Review/merge #32 first.
- Two other LOW / defense-in-depth items from the same review are **not** included here (deliberately, to keep this focused): console-capture can copy `console.error/warn` text (incl. anything the host logs) into the report — worth documenting or adding a redaction opt-out; and `injectSvg`/`type.icon` is safe today but should be documented as trusted-config-only. Happy to open follow-ups.

Generated with Claude Code