### PR TITLE
ci: bump codeql-action to v4.37.2 and group its sub-action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      # github/codeql-action/init and .../analyze are pinned separately but MUST
+      # move together — the analyze step aborts with "Loaded a configuration file
+      # for version 'X', but running version 'Y'" when the two SHAs diverge.
+      # Without this group Dependabot opens one PR per sub-action, and each one
+      # fails CI on its own. See PRs #37 and #39.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+      - uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1  # v4.37.2
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
-      - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+      - uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1  # v4.37.2


### PR DESCRIPTION
Supersedes #24, #33, #37, #39.

## The break

Dependabot pins `github/codeql-action/init` and `github/codeql-action/analyze` as two independent dependencies, so it opens a separate PR for each. Merging either alone leaves the two SHAs mismatched and the analyze step aborts:

```
##[error]Loaded a configuration file for version '4.37.2', but running version '4.35.2'
```

That is exactly why #37 and #39 are both red.

## The fix

1. Move `init` and `analyze` to the same commit — `e0647621c2984b5ed2f768cb892365bf2a616ad1` (verified as the commit behind the annotated `v4.37.2` tag).
2. Add a `groups:` block to `.github/dependabot.yml` matching `github/codeql-action*`, so future releases arrive as one PR instead of two half-bumps.

Without step 2 this breaks again on the next codeql-action release.

## Superseded PRs

| PR | Bumps | Why closed |
|----|-------|------------|
| #24 | both → 4.36.2 | behind 4.37.2 |
| #33 | both → 4.36.3 | behind 4.37.2 |
| #37 | init only → 4.37.2 | half a bump, CI red |
| #39 | analyze only → 4.37.2 | half a bump, CI red |

Generated with Claude Code