### PR TITLE
chore: harden .gitignore and record unreleased changes in CHANGELOG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,21 @@ Thumbs.db
 # Node (dev/test tooling only — the widget itself ships zero dependencies)
 node_modules/
 package-lock.json
+
+# Local agent/tooling state
+.claude/
+.mcp.json
+
+# Never commit — these directories exist in some local checkouts that share a
+# path with a home directory. This repo is public; keep them out by default.
+secrets/
+scripts/
+
+# Stray shell/user dotfiles (see above)
+.bashrc
+.bash_profile
+.profile
+.zshrc
+.zprofile
+.gitconfig
+.ripgreprc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Query strings and fragments are stripped from captured API URLs before they
+  are written into the issue body. The fetch-capture wrapper records recent
+  same-origin `/api/` calls, and query strings on host-app requests can carry
+  secrets (`?token=`, `?sig=`, session ids) that would otherwise be exfiltrated
+  into a potentially public issue. The path is still reported, so the debugging
+  signal is preserved. (#34)
+
+### Fixed
+- **Accessibility:** the report modal now implements the full WAI-ARIA dialog
+  focus-management pattern. Focus moves into the dialog on every step (not just
+  step 1), `Tab`/`Shift+Tab` are trapped and wrap within the modal, the rest of
+  the page is made `inert` + `aria-hidden` while the modal is open, and focus is
+  restored to the triggering element on close by any path. Fixes a WCAG 2.1
+  2.4.3 / 4.1.2 gap. (#26, #34)
+- The `✕` and Done buttons passed the click `Event` as `closeModal`'s
+  `silent` argument, which suppressed state reset and focus restoration. (#34)
+
+### Added
+- CI: `Validate widget + docs integrity` — checks JS syntax and asserts the SRI
+  hash documented in `README.md` and `docs/index.html` matches the sha384 of
+  `issue-reporter.js` at the pinned immutable tag, rejecting mutable refs like
+  `@main`. (#27)
+- CI: `A11y focus tests (jsdom)` — runs `tests/a11y_focus.test.mjs` and
+  `tests/fetch_capture_redaction.test.mjs` on push and PR. (#34)
+
+### Changed
+- CI: `github/codeql-action` bumped to v4.37.2 and `actions/checkout` to v7.0.1,
+  both SHA-pinned. Dependabot now groups the `codeql-action` sub-actions so
+  `init` and `analyze` are bumped in a single PR — splitting them breaks the
+  analyze step with a config-version mismatch. (#38, #40)
+
 ## [2.3.0] - 2026-04-19
 
 ### Removed


### PR DESCRIPTION
Two housekeeping items surfaced while auditing the repo.

## `.gitignore`

Some local checkouts of this repo sit at a path that doubles as a home directory, so `secrets/`, `scripts/`, `.mcp.json`, and shell dotfiles (`.bashrc`, `.zshrc`, `.gitconfig`, …) show up as untracked **and unignored**. This repo is public — one `git add -A` publishes them. Now ignored by default, alongside `.claude/`.

Nothing tracked is affected; these paths have never been committed.

## `CHANGELOG.md`

`## [Unreleased]` was empty even though `main` had already picked up:

- the WAI-ARIA dialog focus fix (#26 / #34)
- API query-string redaction (#34)
- two new CI workflows (#27, #34)
- codeql-action v4.37.2 + dependabot grouping (#38, #40)

All four are now recorded under Keep a Changelog headings.

Note that `main`'s `issue-reporter.js` now differs from the `v2.3.0` tag while `VERSION` still reads `2.3.0` — expected for unreleased work. The README/docs SRI pins point at the immutable tag, so the integrity guard stays green; both will need regenerating at the next release.

Generated with Claude Code